### PR TITLE
Hotfix: Time constraints on event members

### DIFF
--- a/Client/src/components/SingleEvent.js
+++ b/Client/src/components/SingleEvent.js
@@ -172,7 +172,7 @@ const JobDescription = styled.p`
   max-width: 90%;
 `;
 
-const SingleEvent = ({ event, user, userIsMember, claimEventMember, unclaimEventMember }) => (
+const SingleEvent = ({ event, user, userIsMember, claimEventMember, unclaimEventMember, userEventMembers, claimedEventMembers, unclaimedEventMembers}) => (
   <Wrapper>
     <EventName>{event.name}</EventName>
     <OrganizationName href={`/organizations/${event.organization.organizationId}`}>{event.organization.name}</OrganizationName>
@@ -206,7 +206,7 @@ const SingleEvent = ({ event, user, userIsMember, claimEventMember, unclaimEvent
     </NotAMember>
     }
 
-    {event.eventMembers.filter((eMember) => eMember.volunteer !== null && eMember.volunteer.volunteerId === user.id).length > 0 ?
+    {userEventMembers.length > 0 ?
     <div>
       <AvailablePositions>Your Positions</AvailablePositions>
       <Break/>
@@ -217,11 +217,11 @@ const SingleEvent = ({ event, user, userIsMember, claimEventMember, unclaimEvent
 
     {/* Your Positions */}
     <div>
-      {event.eventMembers.filter((eMember) => eMember.volunteer !== null && eMember.volunteer.volunteerId === user.id).map((eMember, index) => {
+      {userEventMembers.map((eMember, index) => {
         return (
           <EventMember key={index}>{/* Loop this div for each open event member */}
             <ClaimBtnWrapper>
-              <UnclaimBtn>UNCLAIM</UnclaimBtn>
+              <UnclaimBtn onClick={unclaimEventMember.bind(null, eMember.eventMemberId)}>UNCLAIM</UnclaimBtn>
             </ClaimBtnWrapper>
             <Job>
               {/* Event Member Title */}
@@ -237,7 +237,7 @@ const SingleEvent = ({ event, user, userIsMember, claimEventMember, unclaimEvent
         );
       })}
     </div>
-    {event.eventMembers.filter((eMember) => eMember.volunteer === null).length > 0 ?
+    {unclaimedEventMembers.length > 0 ?
     <div>
       <AvailablePositions>Available Positions</AvailablePositions>
       <Break/>
@@ -246,11 +246,11 @@ const SingleEvent = ({ event, user, userIsMember, claimEventMember, unclaimEvent
     ''}
     {/* Available Positions */}
     <div>
-      {event.eventMembers.filter((eMember) => eMember.volunteer === null).map((eMember, index) => {
+      {unclaimedEventMembers.map((eMember, index) => {
         return (
           <EventMember key={index}>{/* Loop this div for each open event member */}
             <ClaimBtnWrapper>
-              <ClaimBtn>CLAIM</ClaimBtn>
+              <ClaimBtn onClick={claimEventMember.bind(null, eMember.eventMemberId)}>CLAIM</ClaimBtn>
             </ClaimBtnWrapper>
             <Job>
               {/* Event Member Title */}
@@ -267,7 +267,7 @@ const SingleEvent = ({ event, user, userIsMember, claimEventMember, unclaimEvent
       })}
     </div>
 
-    {event.eventMembers.filter((eMember) => eMember.volunteer !== null && eMember.volunteer.volunteerId !== user.id).length > 0 ?
+    {claimedEventMembers.length > 0 ?
     <div>
       <AvailablePositions>Claimed Positions</AvailablePositions>
       <Break/>
@@ -276,7 +276,7 @@ const SingleEvent = ({ event, user, userIsMember, claimEventMember, unclaimEvent
     ''}
     {/* Available Positions */}
     <div>
-      {event.eventMembers.filter((eMember) => eMember.volunteer !== null && eMember.volunteer.volunteerId !== user.id).map((eMember, index) => {
+      {claimedEventMembers.map((eMember, index) => {
         return (
           <EventMember key={index}>{/* Loop this div for each open event member */}
             <ClaimBtnWrapper>

--- a/Client/src/containers/SingleEventContainer.js
+++ b/Client/src/containers/SingleEventContainer.js
@@ -8,6 +8,12 @@ class SingleEventContainer extends Component {
   constructor(props) {
     super(props);
 
+    this.state = {
+      userEventMembers: [],
+      unclaimedEventMembers: [],
+      claimedEventMembers: []
+    };
+
     this.handleOnClaimEventMember = this.handleOnClaimEventMember.bind(this);
     this.handleOnUnclaimEventMember = this.handleOnUnclaimEventMember.bind(this);
     this._checkIfUserIsMemberOfEvent = this._checkIfUserIsMemberOfEvent.bind(this);
@@ -27,7 +33,16 @@ class SingleEventContainer extends Component {
   }
 
   componentDidUpdate() {
-    window.scrollTo(0, 0);
+    // window.scrollTo(0, 0);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.eventById.eventMembers === undefined) return;
+    this.setState({
+      userEventMembers: nextProps.eventById.eventMembers.filter((eMember) => eMember.volunteer !== null && eMember.volunteer.id === nextProps.user.id),
+      unclaimedEventMembers: nextProps.eventById.eventMembers.filter((eMember) => eMember.volunteer === null),
+      claimedEventMembers: nextProps.eventById.eventMembers.filter((eMember) => eMember.volunteer !== null && eMember.volunteer.id !== nextProps.user.id)
+    });
   }
 
   _checkIfUserIsMemberOfEvent() {
@@ -35,7 +50,7 @@ class SingleEventContainer extends Component {
     if (eventById.eventMembers === undefined) return false;
     if (eventById.eventMembers.length > 0) {
       return eventById.eventMembers.find((eventMember) => {
-        return eventMember.volunteer ? eventMember.volunteer.volunteerId = user.id : false;
+        return eventMember.volunteer ? eventMember.volunteer.id === user.id : false;
       }) ? true : false;
     }
   }
@@ -50,8 +65,11 @@ class SingleEventContainer extends Component {
           event={eventById}
           userIsMember={this._checkIfUserIsMemberOfEvent()}
           user={user}
+          userEventMembers={this.state.userEventMembers}
           claimEventMember={this.handleOnClaimEventMember}
-          unclaimEventMember={this.handleOnUnclaimEventMember}/>
+          claimedEventMembers={this.state.claimedEventMembers}
+          unclaimEventMember={this.handleOnUnclaimEventMember}
+          unclaimedEventMembers={this.state.unclaimedEventMembers}/>
         :
         <div>
           <i className="fa fa-spinner fa-pulse fa-3x fa-fw"></i>

--- a/Client/src/reducers/eventMemberReducer.js
+++ b/Client/src/reducers/eventMemberReducer.js
@@ -85,7 +85,7 @@ export default function eventMemberReducer(state = eventMember, action) {
       return {
         ...state,
         loading: false,
-        eventMember: action.payload.eventMember
+        claimedEventMember: action.payload.eventMember
       };
     case a.CLAIM_EVENT_MEMBER_FAILURE:
       return {
@@ -103,7 +103,7 @@ export default function eventMemberReducer(state = eventMember, action) {
       return {
         ...state,
         loading: false,
-        eventMember: action.payload.eventMember
+        unclaimedEventMember: action.payload.eventMember
       };
     case a.UNCLAIM_EVENT_MEMBER_FAILURE:
       return {

--- a/Client/src/reducers/eventReducer.js
+++ b/Client/src/reducers/eventReducer.js
@@ -127,6 +127,30 @@ export default function eventReducer(state = event, action) {
         loadingDeleteEvent: false,
         error: action.payload.error
       };
+    case a.CLAIM_EVENT_MEMBER_SUCCESS:
+      return {
+        ...state,
+        eventById: {
+          ...state.eventById,
+          eventMembers: [
+            ...state.eventById.eventMembers.slice(0, state.eventById.eventMembers.indexOf(state.eventById.eventMembers.find(x => x.eventMemberId === action.payload.eventMember.eventMemberId))),
+            action.payload.eventMember,
+            ...state.eventById.eventMembers.slice(state.eventById.eventMembers.indexOf(state.eventById.eventMembers.find(x => x.eventMemberId === action.payload.eventMember.eventMemberId)) + 1),
+          ]
+        }
+      };
+    case a.UNCLAIM_EVENT_MEMBER_SUCCESS:
+      return {
+        ...state,
+        eventById: {
+          ...state.eventById,
+          eventMembers: [
+            ...state.eventById.eventMembers.slice(0, state.eventById.eventMembers.indexOf(state.eventById.eventMembers.find(x => x.eventMemberId === action.payload.eventMember.eventMemberId))),
+            action.payload.eventMember,
+            ...state.eventById.eventMembers.slice(state.eventById.eventMembers.indexOf(state.eventById.eventMembers.find(x => x.eventMemberId === action.payload.eventMember.eventMemberId)) + 1),
+          ]
+        }
+      };
     default:
       return state;
   }

--- a/Client/src/reducers/initialState.js
+++ b/Client/src/reducers/initialState.js
@@ -14,7 +14,8 @@ const initialState = {
   event: {
     nextEvent: {},
     events: [],
-    eventById: {},
+    eventById: {
+    },
     orgEvents: []
   }
 };


### PR DESCRIPTION
## Status
**READY**

## Documentation

[ ] I have fully documented features in this PR's code. Please put an `X` in the box to confirm.

[X] This PR does **NOT** require documentation.

## Description
Users should not be able to claim event members with conflicting times.

## Resolves Issue Number

